### PR TITLE
Feature/further segregation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transitive"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["bobozaur"]
 description = "Transitive derive macros for Rust."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,15 +15,16 @@
 //! - `#[transitive(into(all(A, B, C)))]` treats every element apart from the first as a target type
 //!
 //! For [`TransitiveTryFrom`] the error types must be convertible to the error type of the last conversion taking place.
+//! Additionally, the attribute arguments become `try_from` and `try_into`.
 //!
 //! # Conversions table:
 //!
-//! | Derived Type | Derive macro             | Annotation                    | Will impl           | Conditions                                                                                                                |
-//! |--------------|--------------------------|-------------------------------|---------------------|---------------------------------------------------------------------------------------------------------------------------|
-//! | A            | [`TransitiveFrom`]       | #[transitive(into(B, C, D))]  | `From<A> for D`     | `From<A> for B`; `From<B> for C`; `From<C> for D`                                                                         |
-//! | A            | [`TransitiveFrom`]       | #[transitive(from(D, C, B))]  | `From<D> for A`     | `From<D> for C`; `From<C> for B`; `From<B> for A`                                                                         |
-//! | A            | [`TransitiveTryFrom`]    | #[transitive(into(B, C, D))]  | `TryFrom<A> for D`  | `TryFrom<A> for B`; `TryFrom<B> for C`; `TryFrom<C> for D`; errors must impl `From<ErrType> for <D as TryFrom<C>>::Error` |
-//! | A            | [`TransitiveTryFrom`]    | #[transitive(from(D, C, B))]  | `TryFrom<D> for A`  | `TryFrom<D> for C`; `TryFrom<C>` for B; `TryFrom<B> for A`; errors must `impl From<ErrType> for <A as TryFrom<B>>::Error` |
+//! | Derived Type | Derive macro             | Annotation                        | Will impl           | Conditions                                                                                                                |
+//! |--------------|--------------------------|-----------------------------------|---------------------|---------------------------------------------------------------------------------------------------------------------------|
+//! | A            | [`TransitiveFrom`]       | #[transitive(into(B, C, D))]      | `From<A> for D`     | `From<A> for B`; `From<B> for C`; `From<C> for D`                                                                         |
+//! | A            | [`TransitiveFrom`]       | #[transitive(from(D, C, B))]      | `From<D> for A`     | `From<D> for C`; `From<C> for B`; `From<B> for A`                                                                         |
+//! | A            | [`TransitiveTryFrom`]    | #[transitive(try_into(B, C, D))]  | `TryFrom<A> for D`  | `TryFrom<A> for B`; `TryFrom<B> for C`; `TryFrom<C> for D`; errors must impl `From<ErrType> for <D as TryFrom<C>>::Error` |
+//! | A            | [`TransitiveTryFrom`]    | #[transitive(try_from(D, C, B))]  | `TryFrom<D> for A`  | `TryFrom<D> for C`; `TryFrom<C>` for B; `TryFrom<B> for A`; errors must `impl From<ErrType> for <A as TryFrom<B>>::Error` |
 //!
 //!
 //! # Examples:
@@ -170,11 +171,11 @@
 //! // target type and `D`, the first element in the type list,
 //! // as source.
 //! #[derive(TransitiveTryFrom)]
-//! #[transitive(from(D, C, B))] // impl TryFrom<D> for A
+//! #[transitive(try_from(D, C, B))] // impl TryFrom<D> for A
 //! struct A;
 //!
 //! #[derive(TransitiveTryFrom)]
-//! #[transitive(from(D, C))] // impl TryFrom<D> for B
+//! #[transitive(try_from(D, C))] // impl TryFrom<D> for B
 //! struct B;
 //! struct C;
 //! struct D;

--- a/src/transitive/fallible/mod.rs
+++ b/src/transitive/fallible/mod.rs
@@ -1,6 +1,6 @@
 use self::{try_from::TryFromHandler, try_into::TryIntoHandler};
 
-use super::direction_handler::DirectionHandler;
+use super::{direction_handler::{DirectionHandler, DirectionKind}, TRY_FROM, TRY_INTO};
 
 mod try_from;
 mod try_into;
@@ -12,11 +12,26 @@ impl DirectionHandler for FallibleTransition {
 
     type FromHandler = TryFromHandler;
 
-    fn make_into_handler(&self) -> Self::IntoHandler {
+    type Kind = FallibleDirection;
+
+    fn handler_into(&self) -> Self::IntoHandler {
         TryIntoHandler
     }
 
-    fn make_from_handler(&self) -> Self::FromHandler {
+    fn handler_from(&self) -> Self::FromHandler {
         TryFromHandler
     }
 }
+
+pub struct FallibleDirection;
+
+impl DirectionKind for FallibleDirection {
+    fn arg_from() -> &'static str {
+        TRY_FROM
+    }
+
+    fn arg_into() -> &'static str {
+        TRY_INTO
+    }
+}
+

--- a/src/transitive/infallible/mod.rs
+++ b/src/transitive/infallible/mod.rs
@@ -1,6 +1,9 @@
 use self::{from::FromHandler, into::IntoHandler};
 
-use super::direction_handler::DirectionHandler;
+use super::{
+    direction_handler::{DirectionHandler, DirectionKind},
+    FROM, INTO,
+};
 
 mod from;
 mod into;
@@ -12,11 +15,25 @@ impl DirectionHandler for InfallibleTransition {
 
     type FromHandler = FromHandler;
 
-    fn make_into_handler(&self) -> Self::IntoHandler {
+    type Kind = InfallibleDirection;
+
+    fn handler_into(&self) -> Self::IntoHandler {
         IntoHandler
     }
 
-    fn make_from_handler(&self) -> Self::FromHandler {
+    fn handler_from(&self) -> Self::FromHandler {
         FromHandler
+    }
+}
+
+pub struct InfallibleDirection;
+
+impl DirectionKind for InfallibleDirection {
+    fn arg_from() -> &'static str {
+        FROM
+    }
+
+    fn arg_into() -> &'static str {
+        INTO
     }
 }

--- a/tests/foreign_types.rs
+++ b/tests/foreign_types.rs
@@ -9,11 +9,11 @@ use std::num::ParseIntError;
 use transitive::{TransitiveFrom, TransitiveTryFrom};
 
 #[derive(TransitiveTryFrom)]
-#[transitive(from(u8, C, B))] // impl TryFrom<u8> for A
+#[transitive(try_from(u8, C, B))] // impl TryFrom<u8> for A
 struct A;
 
 #[derive(TransitiveTryFrom)]
-#[transitive(from(u8, C))] // impl TryFrom<u8> for B
+#[transitive(try_from(u8, C))] // impl TryFrom<u8> for B
 struct B;
 struct C;
 

--- a/tests/try_from.rs
+++ b/tests/try_from.rs
@@ -7,11 +7,11 @@ mod common;
 use transitive::{TransitiveFrom, TransitiveTryFrom};
 
 #[derive(TransitiveTryFrom)]
-#[transitive(from(D, C, B))] // impl TryFrom<D> for A
+#[transitive(try_from(D, C, B))] // impl TryFrom<D> for A
 struct A;
 
 #[derive(TransitiveTryFrom)]
-#[transitive(from(D, C))] // impl TryFrom<D> for B
+#[transitive(try_from(D, C))] // impl TryFrom<D> for B
 struct B;
 struct C;
 struct D;

--- a/tests/try_from_all.rs
+++ b/tests/try_from_all.rs
@@ -7,7 +7,7 @@ mod common;
 use transitive::{TransitiveFrom, TransitiveTryFrom};
 
 #[derive(TransitiveTryFrom)]
-#[transitive(from(all(D, C, B)))] // impl TryFrom<D> and TryFrom<C> for A
+#[transitive(try_from(all(D, C, B)))] // impl TryFrom<D> and TryFrom<C> for A
 struct A;
 struct B;
 struct C;

--- a/tests/try_into.rs
+++ b/tests/try_into.rs
@@ -7,11 +7,11 @@ mod common;
 use transitive::{TransitiveFrom, TransitiveTryFrom};
 
 #[derive(TransitiveTryFrom)]
-#[transitive(into(B, C, D))] // impl TryFrom<A> for D
+#[transitive(try_into(B, C, D))] // impl TryFrom<A> for D
 struct A;
 
 #[derive(TransitiveTryFrom)]
-#[transitive(into(C, D))] // impl TryFrom<B> for  D
+#[transitive(try_into(C, D))] // impl TryFrom<B> for  D
 struct B;
 struct C;
 struct D;

--- a/tests/try_into_all.rs
+++ b/tests/try_into_all.rs
@@ -7,7 +7,7 @@ mod common;
 use transitive::{TransitiveFrom, TransitiveTryFrom};
 
 #[derive(TransitiveTryFrom)]
-#[transitive(into(all(B, C, D)))] // impl TryFrom<A> for C and D
+#[transitive(try_into(all(B, C, D)))] // impl TryFrom<A> for C and D
 struct A;
 struct B;
 struct C;


### PR DESCRIPTION
Implemented `try_from` and `try_into` as attribute arguments for the `TransitiveTryFrom` derive macro so as not to conflict with the type lists provided for `TransitiveFrom` through the `from` and `into` arguments.