### PR TITLE
Distinct types check

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,12 +8,12 @@ on:
     branches: ["main"]
 
 env:
-  RUST_TOOLCHAIN: 1.74.0
+  RUST_TOOLCHAIN: 1.77.0
 
 jobs:
   format:
     name: Format
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
@@ -33,7 +33,7 @@ jobs:
   clippy:
     name: Clippy
     needs: format
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
@@ -54,11 +54,10 @@ jobs:
         env:
           RUSTFLAGS: -D warnings
 
-  
   tests:
     name: Tests
     needs: clippy
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,22 +34,7 @@
 //! overrides the default behavior and allows specifying a custom error type, but all the error
 //! types resulting from conversions must be convertible to this type.
 //!
-//! # Conversion type list
-//!
-//! Regardless of the conversion performed, the list of types provided to the attribute must contain
-//! at least two types. A compilation error takes place otherwise:
-//!
-//! ```compile_fail
-//! use transitive::Transitive;
-//!
-//! struct A;
-//! #[derive(Transitive)]
-//! #[transitive(from(A))] // fails to compile
-//! struct B;
-//! ```
-//!
 //! # Examples:
-//!
 //! ```
 //! use transitive::Transitive;
 //!
@@ -86,7 +71,6 @@
 //! ```
 //!
 //! Note that the macro does nothing for types in the middle:
-//!
 //! ```compile_fail
 //! use transitive::Transitive;
 //!
@@ -118,7 +102,6 @@
 //! D::from(A); // works
 //! C::from(A); // does not compile
 //! ```
-//!
 //! ```
 //! use transitive::Transitive;
 //!
@@ -153,7 +136,6 @@
 //!
 //! Let's see an example on how to use [`Transitive`] when combining the "reversed"
 //! nature of the `from` and `try_from` attribute modifiers and the error transitions constraints:
-//!
 //! ```
 //! #![allow(non_camel_case_types)]
 //! use transitive::Transitive;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@
 //! types resulting from conversions must be convertible to this type.
 //!
 //! # Examples:
+//!
 //! ```
 //! use transitive::Transitive;
 //!
@@ -71,6 +72,7 @@
 //! ```
 //!
 //! Note that the macro does nothing for types in the middle:
+//!
 //! ```compile_fail
 //! use transitive::Transitive;
 //!
@@ -102,6 +104,7 @@
 //! D::from(A); // works
 //! C::from(A); // does not compile
 //! ```
+//!
 //! ```
 //! use transitive::Transitive;
 //!
@@ -136,6 +139,7 @@
 //!
 //! Let's see an example on how to use [`Transitive`] when combining the "reversed"
 //! nature of the `from` and `try_from` attribute modifiers and the error transitions constraints:
+//!
 //! ```
 //! #![allow(non_camel_case_types)]
 //! use transitive::Transitive;

--- a/src/transitive/fallible/try_from.rs
+++ b/src/transitive/fallible/try_from.rs
@@ -5,15 +5,15 @@ use syn::{
     Result as SynResult,
 };
 
-use super::FalliblePathList;
+use super::FallibleTypeList;
 use crate::transitive::TokenizablePath;
 
 /// Path corresponding to a [`#[transitive(try_from(..))`] path.
-pub struct TryTransitionFrom(FalliblePathList);
+pub struct TryTransitionFrom(FallibleTypeList);
 
 impl Parse for TryTransitionFrom {
     fn parse(input: ParseStream) -> SynResult<Self> {
-        FalliblePathList::parse(input).map(Self)
+        FallibleTypeList::parse(input).map(Self)
     }
 }
 

--- a/src/transitive/fallible/try_into.rs
+++ b/src/transitive/fallible/try_into.rs
@@ -5,15 +5,15 @@ use syn::{
     Result as SynResult,
 };
 
-use super::FalliblePathList;
+use super::FallibleTypeList;
 use crate::transitive::TokenizablePath;
 
 /// Path corresponding to a [`#[transitive(try_into(..))`] path.
-pub struct TryTransitionInto(FalliblePathList);
+pub struct TryTransitionInto(FallibleTypeList);
 
 impl Parse for TryTransitionInto {
     fn parse(input: ParseStream) -> SynResult<Self> {
-        FalliblePathList::parse(input).map(Self)
+        FallibleTypeList::parse(input).map(Self)
     }
 }
 

--- a/src/transitive/infallible/from.rs
+++ b/src/transitive/infallible/from.rs
@@ -32,7 +32,7 @@ impl ToTokens for TokenizablePath<'_, &TransitionFrom> {
             .chain(std::iter::once(last))
             .map(|ty| quote! {let val: #ty = core::convert::From::from(val);})
             .chain(std::iter::once(quote! {core::convert::From::from(val)}));
-        
+
         let types_check = distinct_types_check(
             first,
             last,

--- a/src/transitive/infallible/from.rs
+++ b/src/transitive/infallible/from.rs
@@ -5,15 +5,15 @@ use syn::{
     Result as SynResult,
 };
 
-use super::PathList;
+use super::TypeList;
 use crate::transitive::TokenizablePath;
 
 /// Path corresponding to a [`#[transitive(from(..))`] path.
-pub struct TransitionFrom(PathList);
+pub struct TransitionFrom(TypeList);
 
 impl Parse for TransitionFrom {
     fn parse(input: ParseStream) -> SynResult<Self> {
-        PathList::parse(input).map(Self)
+        TypeList::parse(input).map(Self)
     }
 }
 

--- a/src/transitive/infallible/into.rs
+++ b/src/transitive/infallible/into.rs
@@ -5,15 +5,15 @@ use syn::{
     Result as SynResult,
 };
 
-use super::PathList;
+use super::TypeList;
 use crate::transitive::TokenizablePath;
 
 /// Path corresponding to a [`#[transitive(into(..))`] path.
-pub struct TransitionInto(PathList);
+pub struct TransitionInto(TypeList);
 
 impl Parse for TransitionInto {
     fn parse(input: ParseStream) -> SynResult<Self> {
-        PathList::parse(input).map(Self)
+        TypeList::parse(input).map(Self)
     }
 }
 

--- a/tests/from.rs
+++ b/tests/from.rs
@@ -9,7 +9,7 @@ use transitive::Transitive;
 struct A;
 
 #[derive(Transitive)]
-#[transitive(from(D, C))] // impl From<D> for A
+#[transitive(from(D, C))] // impl From<D> for B
 struct B;
 struct C;
 struct D;
@@ -21,7 +21,7 @@ impl_from!(D to C);
 #[allow(clippy::duplicated_attributes)]
 #[derive(Transitive)]
 #[transitive(from(D, C, B, A))] // impl From<D> for Z<T>
-#[transitive(from(C, B))] // impl From<D> for Z<T>
+#[transitive(from(C, B))] // impl From<C> for Z<T>
 struct Z<T>(PhantomData<T>);
 
 impl<T> From<A> for Z<T> {


### PR DESCRIPTION
Wraps up the issue reported in #13 and partially addressed in #14. Another requirement to enforce should be that there are at least two distinct types in the type list. This ensures there's some valid conversion path to be taken and avoids infinite recursion.

This PR achieves that by checking that the first and last types in the list are distinct. This is sufficient since the derived type must have a direct conversion to one of them already and the macro generates the conversion to the other one, so having them equal makes no sense.

